### PR TITLE
修复跳转不对，和跳转后获取到的 active anchor 不对的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scrollable-anchor",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Provide smooth scrolling anchors in React.",
   "main": "lib/index.js",
   "files": [

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -95,18 +95,16 @@ class Manager {
   }
 
   goToSection = (id) => {
-    const container = this.config.container
     let element = this.anchors[id]
-    let viewHeight = container.innerHeight || container.clientHeight
-    let offset = this.config.offset + viewHeight / 2 - getOffsetTopToBody(container)
+    let scrollTo = element ? element.offsetTop - this.config.offset : 0
     if (element) {
-      this.config.scroller.center(element, this.config.scrollDuration, offset)
+      this.config.scroller.toY(scrollTo)
     } else {
       // make sure that standard hash anchors don't break.
       // simply jump to them.
       element = document.getElementById(id)
       if (element) {
-        this.config.scroller.center(element, 0, this.config.offset)
+        this.config.scroller.to(element)
       }
     }
   }

--- a/src/utils/scroll.js
+++ b/src/utils/scroll.js
@@ -69,7 +69,7 @@ export const getBestAnchorGivenScrollLocation = (anchors, offset, container) => 
 
   Object.keys(anchors).forEach((id) => {
     const element = anchors[id]
-    if (doesElementContainScrollTop(element, container, offset)) {
+    if (doesElementContainScrollTop(element, container)) {
       if (!bestElement || checkElementRelevance(bestElement, element, container)) {
         bestElement = element
         bestId = id


### PR DESCRIPTION
1、用 toY 代替 center，方便跳转到顶部。
2、doesElementContainScrollTop 不传 offset 了，因为现在是默认跳转到顶部的